### PR TITLE
Keep git version for future reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ RUN apk update
 RUN apk upgrade
 RUN apk add bash g++ make python git
 
+ARG GIT_VERSION=0
+LABEL vcs-ref=$GIT_VERSION
+
 WORKDIR /usr/src/batch-explorer
 
 COPY package*.json ./


### PR DESCRIPTION
Add label to docker image with the git version to maintain a link between docker and git worlds 