### PR TITLE
Display both amount and load amount for CreateAccountDepositTransfer & DepositTransfer

### DIFF
--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -9,9 +9,7 @@ function getTransactionAmount (transaction) {
     return transaction.amount
   } else {
     if (transaction.type === TxType.Deposit ||
-      transaction.type === TxType.CreateAccountDeposit ||
-      transaction.type === TxType.CreateAccountDepositTransfer ||
-      transaction.type === TxType.DepositTransfer) {
+      transaction.type === TxType.CreateAccountDeposit) {
       return transaction.L1Info.depositAmount
     } else {
       return transaction.amount
@@ -19,6 +17,18 @@ function getTransactionAmount (transaction) {
   }
 }
 
+function getTransactionDepositAmount (transaction) {
+  if (!transaction) {
+    return undefined
+  }
+
+  if (transaction.type === TxType.CreateAccountDepositTransfer ||
+    transaction.type === TxType.DepositTransfer) {
+    return transaction.L1Info?.depositAmount
+  }
+}
+
 export {
-  getTransactionAmount
+  getTransactionAmount,
+  getTransactionDepositAmount
 }

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -8,7 +8,10 @@ function getTransactionAmount (transaction) {
   if (!transaction.L1Info) {
     return transaction.amount
   } else {
-    if (transaction.type === TxType.Deposit || transaction.type === TxType.CreateAccountDeposit) {
+    if (transaction.type === TxType.Deposit ||
+      transaction.type === TxType.CreateAccountDeposit ||
+      transaction.type === TxType.CreateAccountDepositTransfer ||
+      transaction.type === TxType.DepositTransfer) {
       return transaction.L1Info.depositAmount
     } else {
       return transaction.amount

--- a/src/views/transaction/transaction.view.jsx
+++ b/src/views/transaction/transaction.view.jsx
@@ -247,6 +247,18 @@ function Transaction ({
                         {getFixedTokenAmount(getTransactionAmount(transactionTask.data), transactionTask.data.token.decimals)} {transactionTask.data.token.symbol}
                       </Col>
                     </Row>
+                    {transactionTask.data.type === 'CreateAccountDepositTransfer' || transactionTask.data.type === 'DepositTransfer'
+                      ? (
+                        <Row>
+                          <Col>
+                            Deposit Amount
+                          </Col>
+                          <Col>
+                            {getFixedTokenAmount(getTransactionAmount(transactionTask.data), transactionTask.data.token.decimals)} {transactionTask.data.token.symbol}
+                          </Col>
+                        </Row>
+                        )
+                      : <></>}
                     {transactionTask.data.fee || transactionTask.data.L2Info?.fee
                       ? (
                         <Row>

--- a/src/views/transaction/transaction.view.jsx
+++ b/src/views/transaction/transaction.view.jsx
@@ -112,8 +112,6 @@ function Transaction ({
     }
   }
 
-  console.log('transactionTask.data: ', transactionTask.data?.type)
-
   return (
     <div className={classes.root}>
       <Container disableTopGutter>
@@ -249,7 +247,7 @@ function Transaction ({
                         {getFixedTokenAmount(getTransactionAmount(transactionTask.data), transactionTask.data.token.decimals)} {transactionTask.data.token.symbol}
                       </Col>
                     </Row>
-                    {transactionTask.data.type === 'CreateAccountDepositTransfer' || transactionTask.data.type === 'DepositTransfer'
+                    {transactionTask.data.type === TxType.CreateAccountDepositTransfer || transactionTask.data.type === TxType.DepositTransfer
                       ? (
                         <Row>
                           <Col>

--- a/src/views/transaction/transaction.view.jsx
+++ b/src/views/transaction/transaction.view.jsx
@@ -18,7 +18,7 @@ import Row from '../shared/row/row'
 import Col from '../shared/col/col'
 import Title from '../shared/title/title'
 import { getFixedTokenAmount, getFeeInUsd } from '../../utils/currencies'
-import { getTransactionAmount } from '../../utils/transactions'
+import { getTransactionAmount, getTransactionDepositAmount } from '../../utils/transactions'
 
 function Transaction ({
   onLoadTransaction,
@@ -111,6 +111,8 @@ function Transaction ({
       return false
     }
   }
+
+  console.log('transactionTask.data: ', transactionTask.data?.type)
 
   return (
     <div className={classes.root}>
@@ -254,7 +256,7 @@ function Transaction ({
                             Deposit Amount
                           </Col>
                           <Col>
-                            {getFixedTokenAmount(getTransactionAmount(transactionTask.data), transactionTask.data.token.decimals)} {transactionTask.data.token.symbol}
+                            {getFixedTokenAmount(getTransactionDepositAmount(transactionTask.data), transactionTask.data.token.decimals)} {transactionTask.data.token.symbol}
                           </Col>
                         </Row>
                         )


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #185 

### What does this PR does?

Display both amount and load amount for CreateAccountDepositTransfer & DepositTransfer

### How to test?

Check transaction details for different types of transactions. DepositAmount is used in tx types Deposit, CreateAccountDeposit, CreateAccountDepositTransfer & DepositTransfer
amount is used in CreateAccountDepositTransfer, DepositTransfer, forceTransfer & forceExit. CreateAccountDepositTransfer & DepositTransfer transactions types has both values.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [ ] Update documentation (if needed)
